### PR TITLE
Fix: conan package again

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,9 +11,7 @@ class Recipe(ConanFile):
     topics = "c++20", "hash-map", "data-structures", "header-only", "hash-table"
     settings = "os", "compiler", "build_type", "arch"
     exports_sources = "include/*", "CMakeLists.txt", "cmake/*", "LICENSE*"
-    package_type = "header-library"
     generators = "CMakeDeps", "CMakeToolchain"
-    no_copy_source = True
     options = {
         "with_test_deps": [True, False],
     }


### PR DESCRIPTION
remove header-only and no-copy-source.

`build()` is not executed with `header-only` enabled, and `no_copy_source` is wrong here