### PR TITLE
Pin cpp-conan-release-reusable-workflow to v1.0.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Cache conan data
         id: cache-conan
-        uses: actions/cache@v6.1
+        uses: actions/cache@v6.1.0
         with:
           path: ~/.conan2/p
           key: ${{ matrix.config.os }}-${{ matrix.config.cxx }}-conan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       # setup env
       - name: Add repos for for gcc-13 and clang-16
-        uses: dice-group/cpp-conan-release-reusable-workflow/.github/actions/setup_apt@main
+        uses: dice-group/cpp-conan-release-reusable-workflow/.github/actions/setup_apt@v1.0.3
 
       - name: Install tools
         run: |
@@ -51,7 +51,7 @@ jobs:
         uses: rui314/setup-mold@v1
 
       - name: Configure conan
-        uses: dice-group/cpp-conan-release-reusable-workflow/.github/actions/configure_conan@main
+        uses: dice-group/cpp-conan-release-reusable-workflow/.github/actions/configure_conan@v1.0.3
         with:
           conan-version: 2.3.1
 
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@v4.1.6
 
       - name: Get dependency provider
-        uses: dice-group/cpp-conan-release-reusable-workflow/.github/actions/add_conan_provider@main
+        uses: dice-group/cpp-conan-release-reusable-workflow/.github/actions/add_conan_provider@v1.0.3
 
       - name: Configure CMake
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,18 +9,18 @@ jobs:
       matrix:
         config:
           - name: linux-x64-clang-15
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             cxx: clang++-15
           - name: linux-x64-clang-16-sanitize
-            os: ubuntu-20.04
+            os: ubuntu-24.04
             cxx: clang++-16
             cxx-flags: "-fsanitize=address,undefined"
 
           - name: linux-x64-gcc-12
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             cxx: g++-12
           - name: linux-x64-gcc-13-coverage
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             cxx: g++-13
             cxx-flags: -Werror --coverage
             gcov-tool: gcov-10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,13 @@ jobs:
 
       - name: Cache conan data
         id: cache-conan
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v6.1
         with:
           path: ~/.conan2/p
           key: ${{ matrix.config.os }}-${{ matrix.config.cxx }}-conan
 
       - name: Check out sources
-        uses: actions/checkout@v4.1.6
+        uses: actions/checkout@v7
 
       - name: Get dependency provider
         uses: dice-group/cpp-conan-release-reusable-workflow/.github/actions/add_conan_provider@v1.0.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,12 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - name: linux-x64-clang-15
+          - name: linux-x64-clang-19
             os: ubuntu-24.04
-            cxx: clang++-15
-          - name: linux-x64-clang-16-sanitize
+            cxx: clang++-19
+          - name: linux-x64-clang-19-sanitize
             os: ubuntu-24.04
-            cxx: clang++-16
+            cxx: clang++-19
             cxx-flags: "-fsanitize=address,undefined"
 
           - name: linux-x64-gcc-12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Configure conan
         uses: dice-group/cpp-conan-release-reusable-workflow/.github/actions/configure_conan@v1.0.3
         with:
-          conan-version: 2.3.1
+          conan-version: 2.21.0
 
       - name: add conan user
         run: |

--- a/.github/workflows/detect-pobr-diff.yml
+++ b/.github/workflows/detect-pobr-diff.yml
@@ -12,8 +12,8 @@ jobs:
     with:
       os: ubuntu-24.04
       setup_tools: true
-      cc: clang-20
-      cxx: clang++-20
+      cc: clang-19
+      cxx: clang++-19
       cmake-version: 3.24.0
       conan-version: 2.21.0
       base-branch: ${{ github.base_ref }}

--- a/.github/workflows/detect-pobr-diff.yml
+++ b/.github/workflows/detect-pobr-diff.yml
@@ -10,7 +10,7 @@ jobs:
   detect-pobr-diff:
     uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/abi-diff.yml@v1.0.3
     with:
-      os: ubuntu-22.04
+      os: ubuntu-24.04
       compiler: clang-16
       cmake-version: 3.24.0
       conan-version: 2.3.1

--- a/.github/workflows/detect-pobr-diff.yml
+++ b/.github/workflows/detect-pobr-diff.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   detect-pobr-diff:
-    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/abi-diff.yml@main
+    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/abi-diff.yml@v1.0.3
     with:
       os: ubuntu-22.04
       compiler: clang-16

--- a/.github/workflows/detect-pobr-diff.yml
+++ b/.github/workflows/detect-pobr-diff.yml
@@ -11,10 +11,11 @@ jobs:
     uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/abi-diff.yml@v1.0.3
     with:
       os: ubuntu-24.04
+      setup_tools: true
       cc: clang-20
       cxx: clang++-20
       cmake-version: 3.24.0
-      conan-version: 2.3.1
+      conan-version: 2.21.0
       base-branch: ${{ github.base_ref }}
       search-path: >
         include/dice/sparse-map/sparse_growth_policy.hpp

--- a/.github/workflows/detect-pobr-diff.yml
+++ b/.github/workflows/detect-pobr-diff.yml
@@ -11,7 +11,8 @@ jobs:
     uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/abi-diff.yml@v1.0.3
     with:
       os: ubuntu-24.04
-      compiler: clang-16
+      cc: clang-20
+      cxx: clang++-20
       cmake-version: 3.24.0
       conan-version: 2.3.1
       base-branch: ${{ github.base_ref }}

--- a/.github/workflows/publish-conan-branch-package.yml
+++ b/.github/workflows/publish-conan-branch-package.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   publish-conan-branch-package:
-    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-conan-branch-package.yml@main
+    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-conan-branch-package.yml@v1.0.3
     with:
       public_artifactory: true
       os: ubuntu-22.04

--- a/.github/workflows/publish-conan-branch-package.yml
+++ b/.github/workflows/publish-conan-branch-package.yml
@@ -14,7 +14,7 @@ jobs:
       os: ubuntu-24.04
       compiler: clang-14
       cmake-version: 3.24.0
-      conan-version: 2.3.0
+      conan-version: 2.21.0
     secrets:
       CONAN_USER: ${{ secrets.CONAN_USER }}
       CONAN_PW: ${{ secrets.CONAN_PW }}

--- a/.github/workflows/publish-conan-branch-package.yml
+++ b/.github/workflows/publish-conan-branch-package.yml
@@ -12,7 +12,7 @@ jobs:
     with:
       public_artifactory: true
       os: ubuntu-24.04
-      compiler: clang-14
+      compiler: clang-19
       cmake-version: 3.24.0
       conan-version: 2.21.0
     secrets:

--- a/.github/workflows/publish-conan-branch-package.yml
+++ b/.github/workflows/publish-conan-branch-package.yml
@@ -11,7 +11,7 @@ jobs:
     uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-conan-branch-package.yml@v1.0.3
     with:
       public_artifactory: true
-      os: ubuntu-22.04
+      os: ubuntu-24.04
       compiler: clang-14
       cmake-version: 3.24.0
       conan-version: 2.3.0

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   publish-release:
-    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-release.yml@main
+    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-release.yml@v1.0.3
     with:
       public_artifactory: true
       os: ubuntu-22.04

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,7 +16,7 @@ jobs:
     uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-release.yml@v1.0.3
     with:
       public_artifactory: true
-      os: ubuntu-22.04
+      os: ubuntu-24.04
       compiler: clang-14
       cmake-version: 3.24.0
       conan-version: 2.3.0

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,7 +17,7 @@ jobs:
     with:
       public_artifactory: true
       os: ubuntu-24.04
-      compiler: clang-14
+      compiler: clang-19
       cmake-version: 3.24.0
       conan-version: 2.21.0
     secrets:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,7 +19,7 @@ jobs:
       os: ubuntu-24.04
       compiler: clang-14
       cmake-version: 3.24.0
-      conan-version: 2.3.0
+      conan-version: 2.21.0
     secrets:
       CONAN_USER: ${{ secrets.CONAN_USER }}
       CONAN_PW: ${{ secrets.CONAN_PW }}


### PR DESCRIPTION
Previously referenced @main, so any change to that repo took effect immediately here with no version buffer. Pinning to v1.0.3 removes that coupling.